### PR TITLE
build: fix error spawn node enoent node js child process in web dev

### DIFF
--- a/packages/web-server/build-config/vite.config.ts
+++ b/packages/web-server/build-config/vite.config.ts
@@ -25,6 +25,8 @@ export const runServer = (onLog: (data: Buffer, color: 'red' | 'blue') => void) 
     cwd: projectPath,
     env: {
       NODE_OPTIONS: '--enable-source-maps',
+      // reference https://maxschmitt.me/posts/error-spawn-node-enoent-node-js-child-process
+      PATH: process.env.PATH,
     },
   })
 
@@ -98,8 +100,8 @@ export const buildConfig = (mode: string): UserConfig => {
       watch: isProd
         ? null
         : {
-            buildDelay: 500,
-          },
+          buildDelay: 500,
+        },
       commonjsOptions: {
         // dynamicRequireTargets: ['*.js'],
         ignoreDynamicRequires: true,


### PR DESCRIPTION
在进行web版本开发时遇到了报错信息：**Error: spawn node ENOENT**

### 解决方案

> 摘录：The reason the spawn was broken in the first place was because we were overriding the child process' environment variables in options.env which it normally would have inherited from its parent process.
So without the PATH environment variable, the operating system doesn't know where to look for the node executable.

- 参考
    1. https://maxschmitt.me/posts/error-spawn-node-enoent-node-js-child-process

### 重现步骤
1. git clone项目，切换到dev分支
1. 执行
``` shell
pnpm i
pnpm run dev:web
```

### 报错信息
``` shell
Error: spawn node ENOENT
    at Process.ChildProcess._handle.onexit (node:internal/child_process:285:19)
    at onErrorNT (node:internal/child_process:483:16)
    at processTicksAndRejections (node:internal/process/task_queues:90:21) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'spawn node',
  path: 'node',
  spawnargs: [ '/workspaces/any-listen/packages/web-server/index.cjs' ]
}
/workspaces/any-listen/packages/shared/scripts:
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  @shared/scripts@ dev:web: `ts-node dev-web.ts`
Exit status 1
 ELIFECYCLE  Command failed with exit code 1.
```