### PR TITLE
fix(mac): enable window dragging on aside area with proper interactiv…

### DIFF
--- a/packages/view-main/src/components/layout/Aside/MyList/ListItem.svelte
+++ b/packages/view-main/src/components/layout/Aside/MyList/ListItem.svelte
@@ -34,7 +34,7 @@
 </script>
 
 <div
-  class="container"
+  class="container no-drag"
   class:active={$query.id == listInfo.id || active}
   class:fetching={fetching.val}
   role="button"

--- a/packages/view-main/src/components/layout/Aside/Nav.svelte
+++ b/packages/view-main/src/components/layout/Aside/Nav.svelte
@@ -112,7 +112,7 @@
 })}
   <li class="nav-item" role="presentation">
     <a
-      class="link"
+      class="link no-drag"
       class:active={activePath == item.to}
       role="tab"
       data-ignore-tip

--- a/packages/view-main/src/components/layout/Aside/index.svelte
+++ b/packages/view-main/src/components/layout/Aside/index.svelte
@@ -1,4 +1,4 @@
-<script>
+<script lang="ts">
   import Logo from './Logo.svelte'
   import Nav from './Nav.svelte'
   import MyList from './MyList/index.svelte'
@@ -8,7 +8,7 @@
   // console.log(params)
 </script>
 
-<div class="aside">
+<div class="aside" class:drag={import.meta.env.VITE_IS_DESKTOP}>
   {#if !import.meta.env.VITE_IS_MAC}
     <Logo />
   {/if}


### PR DESCRIPTION
## Summary

修复 macOS 桌面端 Aside 侧边栏区域无法拖动窗口的问题。

## Changes

- `Aside/index.svelte`: 添加 `class:drag={import.meta.env.VITE_IS_DESKTOP}` 启用窗口拖动
- `Aside/Nav.svelte`: 导航链接添加 `no-drag` 类，保留点击跳转功能
- `Aside/MyList/ListItem.svelte`: 列表项容器添加 `no-drag` 类，保留选中切换功能

## Technical Details

`-webkit-app-region` CSS 属性用于控制 Electron 应用中的窗口拖动行为。`drag` 类启用窗口拖动，`no-drag` 显式标记交互元素保持可点击。

这些 CSS 规则仅在 `html.desktop` 上下文中生效，Windows/Linux/Web 版本不受影响。

## Testing

- [x] macOS 上可通过 aside 区域拖动窗口
- [x] 导航链接保持可点击
- [x] 列表项可正常选中/切换
- [x] 交通灯按钮（关闭/最小化）正常工作

https://github.com/user-attachments/assets/c144419b-bde0-4011-b64c-2560aeb6b5e1