### PR TITLE
fix(mac): enable window dragging on aside titlebar area

### DIFF
--- a/packages/view-main/src/components/layout/Aside/index.svelte
+++ b/packages/view-main/src/components/layout/Aside/index.svelte
@@ -6,7 +6,12 @@
   // export let params = {}
 
   // console.log(params)
+  import { windowDarg } from '@/shared/browser/widnow.svelte'
 </script>
+
+{#if import.meta.env.VITE_IS_DESKTOP && import.meta.env.VITE_IS_MAC}
+  <div class="aside-drag-handle drag" {@attach windowDarg}></div>
+{/if}
 
 <div class="aside">
   {#if !import.meta.env.VITE_IS_MAC}
@@ -46,6 +51,15 @@
 
   :global(html.desktop.mac .aside) {
     padding-top: calc(env(titlebar-area-height, 30px) + 4px);
+  }
+
+  .aside-drag-handle {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: calc(env(titlebar-area-height, 30px) + 4px);
+    z-index: 10;
   }
 
   // :global(html.mac .aside-nav) {

--- a/packages/view-main/src/components/layout/Header/index.svelte
+++ b/packages/view-main/src/components/layout/Header/index.svelte
@@ -62,6 +62,10 @@
     align-items: center;
     height: 100%;
     margin-left: 12px;
+
+    :global(html.mac) & {
+      margin-left: 0;
+    }
     :global {
       .search-input {
         // background-color: transparent;


### PR DESCRIPTION
### 修复说明
修复 macOS 桌面端窗口拖动问题，主要解决 Aside 侧边栏顶部空白区域（padding-top 区域）无法拖动窗口的问题。

### 修改内容
文件 修改说明 Aside/index.svelte 添加独立的拖动手柄 .aside-drag-handle ，占用 macOS 标题栏空白区域（padding-top），仅在 macOS 桌面版渲染 Header/index.svelte .left 容器添加 margin-left: 0 (macOS 专用)，解决搜索框与交通灯按钮区域重叠问题

### 技术实现
- 使用 import.meta.env.VITE_IS_DESKTOP && import.meta.env.VITE_IS_MAC 条件判断，仅在 macOS 桌面版添加拖动手柄
- 拖动手柄采用绝对定位，高度与 padding-top 保持一致 ( env(titlebar-area-height, 30px) + 4px )
- Aside 内容区域（Nav、MyList）保持非拖动状态，确保交互元素正常运作
### 影响范围
- 仅影响 macOS 桌面版
- Windows、Linux、Docker 版本不受影响
- Web 版本不受影响

### 演示视频

https://github.com/user-attachments/assets/8bc63c88-48fc-4084-8da6-00b6e623089f

