### PR TITLE
在线资源返回空结果时不缓存，避免可能的网络波动污染缓存

### DIFF
--- a/packages/view-main/src/modules/resource/search/music/actions.ts
+++ b/packages/view-main/src/modules/resource/search/music/actions.ts
@@ -90,7 +90,11 @@ const setCachedListInfo = (
         listInfo.page = page
         listInfo.limit = limit
         listInfo.total = result.total
-        listInfo.cacheTime = performance.now()
+        if (result.list.length > 0) {
+          listInfo.cacheTime = performance.now()
+        } else {
+          listInfo.requestPromise = undefined
+        }
       }
       return result
     })


### PR DESCRIPTION
gd的api不太稳，限流的时候啥特征也没有就只返回个空结果，现在主程序缓存的时候会先检测是否为空，如果是空的就不缓存了