### PR TITLE
docs: relocate Docker Server deployment guide and refine formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <br />
 
-English | [简体中文](./docs/README_zh.md) | [繁體中文](./docs/README_zh-tw.md)
+**English** | [简体中文](./docs/README_zh.md) | [繁體中文](./docs/README_zh-tw.md)
 
 This project is under active development and currently provides both a **Desktop version** and a **Web service version**.
 
@@ -23,88 +23,7 @@ Grab the latest release and install it from: [https://github.com/any-listen/any-
 
 ## Web Version
 
-You can deploy it directly to your server, or use Docker for deployment.
-
-### Docker Deployment
-
-Image release: [https://hub.docker.com/r/lyswhut/any-listen-web-server](https://hub.docker.com/r/lyswhut/any-listen-web-server)
-
-### Direct Deployment
-
-> Requirement: Node.js 20+
-
-Download the latest version and extract it to your target directory: [https://github.com/any-listen/any-listen-web-server/releases](https://github.com/any-listen/any-listen-web-server/releases)
-
-Refer to [https://github.com/lyswhut/lx-music-sync-server](https://github.com/lyswhut/lx-music-sync-server) for deployment methods. See below for configuration file instructions.
-
-Upgrade steps:
-
-1. Delete the `public` and `server` folders in the old project directory
-2. Upload the new version's `public` and `server` folders to the project directory
-3. Restart the service
-
----
-
-**Usage Example:**
-
-1. Create the configuration file `data/config.cjs`
-
-    ```js
-    const config = {
-      // port: '9500', // Bind port
-      // bindIp: '127.0.0.1', // Bind IP
-      // httpLog: true, // Enable HTTP request logging
-      // 'cors.enabled': false, // Enable CORS
-      // 'cors.whitelist': [ // Allowed CORS domains, empty array allows all
-      //   // 'www.xxx.com',
-      // ],
-      // 'upstreamProxy.enabled': false, // Use proxy for requests
-      // 'upstreamProxy.header': '', // Proxy request header (e.g. `x-real-ip`)
-      // 'extension.ghMirrorHosts': [], // Extension store Github mirror addresses
-      // httpProxy: '', // Proxy server address, e.g. `127.0.0.1:2080`
-
-      // Allowed local directories
-      // allowPublicDir: ['G:', 'E:\\music'], // Windows example
-      // allowPublicDir: ['/music'], // Linux example
-      password: '123456a', // Login password
-    }
-
-    module.exports = config
-    ```
-
-2. Run the Docker container
-
-    > Note: The following command is for example only and cannot be used directly!
-
-    ```bash
-    docker run --volume=/home/music:/music --volume=/data:/server/data -p 8080:9500 -d test:latest
-    ```
-
-#### Environment Variables
-
-|        Variable Name        | Description                                                                                  |
-| :-------------------------: | -------------------------------------------------------------------------------------------- |
-|           `PORT`            | Bind port, default `9500`                                                                    |
-|          `BIND_IP`          | Bind IP, default `127.0.0.1`, set to `0.0.0.0` to accept all IPv4 requests, `::` for all IPs |
-|   `UPSTREAM_PROXY_HEADER`   | Proxy request header (e.g. `x-real-ip`), enables proxy when set                              |
-|     `ALLOW_PUBLIC_DIR`      | Allowed local directories, separate multiple with commas                                     |
-|         `DATA_PATH`         | Data storage path, default `./data`                                                          |
-|         `LOGIN_PWD`         | Login password                                                                               |
-|        `CONFIG_PATH`        | Config file path, default `./data/config.js`                                                 |
-|         `LOG_PATH`          | Log storage path, default `./data/logs`                                                      |
-| `EXTENSION_GH_MIRROR_HOSTS` | Extension store Github mirror addresses, separate multiple with commas                       |
-|        `HTTP_PROXY`         | Proxy server, e.g. `127.0.0.1:2080`                                                          |
-
-### Build from Source
-
-```bash
-pnpm install
-pnpm run build:web
-cd build
-mkdir data
-# Create config file config.cjs
-node index.cjs
-```
+You can deploy it directly to your server, or use Docker for deployment. See the [guide](docker-server.md) for deployment steps, environment variables, and build from source code.
 
 ## Contributing
 

--- a/docker-server.md
+++ b/docker-server.md
@@ -1,0 +1,83 @@
+# Docker server deployment guide
+
+## Docker deployment
+
+Image release: [https://hub.docker.com/r/lyswhut/any-listen-web-server](https://hub.docker.com/r/lyswhut/any-listen-web-server)
+
+## Direct deployment
+
+> [!TIP]
+> Requires Node.js 20+
+
+Download the latest version and extract it to your target directory: [https://github.com/any-listen/any-listen-web-server/releases](https://github.com/any-listen/any-listen-web-server/releases)
+
+Refer to [https://github.com/lyswhut/lx-music-sync-server](https://github.com/lyswhut/lx-music-sync-server) for deployment methods. See below for configuration file instructions.
+
+Upgrade steps:
+
+1. Delete the `public` and `server` folders in the old project directory
+2. Upload the new version's `public` and `server` folders to the project directory
+3. Restart the service
+
+---
+
+**Usage example:**
+
+1. Create the configuration file `data/config.cjs`
+
+    ```js
+    const config = {
+      // port: '9500', // Bind port
+      // bindIp: '127.0.0.1', // Bind IP
+      // httpLog: true, // Enable HTTP request logging
+      // 'cors.enabled': false, // Enable CORS
+      // 'cors.whitelist': [ // Allowed CORS domains, empty array allows all
+      //   // 'www.xxx.com',
+      // ],
+      // 'upstreamProxy.enabled': false, // Use proxy for requests
+      // 'upstreamProxy.header': '', // Proxy request header (e.g. `x-real-ip`)
+      // 'extension.ghMirrorHosts': [], // Extension store GitHub mirror addresses
+      // httpProxy: '', // Proxy server address, e.g. `127.0.0.1:2080`
+
+      // Allowed local directories
+      // allowPublicDir: ['G:', 'E:\\music'], // Windows example
+      // allowPublicDir: ['/music'], // Linux example
+      password: '123456a', // Login password
+    }
+
+    module.exports = config
+    ```
+
+2. Run the Docker container
+
+    > Note: The following command is for example only and cannot be used directly!
+
+    ```bash
+    docker run --volume=/home/music:/music --volume=/data:/server/data -p 8080:9500 -d test:latest
+    ```
+
+### Environment variables
+
+|        Variable Name        | Description                                                                                  |
+| :-------------------------: | -------------------------------------------------------------------------------------------- |
+|           `PORT`            | Bind port, default `9500`                                                                    |
+|          `BIND_IP`          | Bind IP, default `127.0.0.1`, set to `0.0.0.0` to accept all IPv4 requests, `::` for all IPs |
+|   `UPSTREAM_PROXY_HEADER`   | Proxy request header (e.g. `x-real-ip`), enables proxy when set                              |
+|     `ALLOW_PUBLIC_DIR`      | Allowed local directories, separate multiple with commas                                     |
+|         `DATA_PATH`         | Data storage path, default `./data`                                                          |
+|         `LOGIN_PWD`         | Login password                                                                               |
+|        `CONFIG_PATH`        | Config file path, default `./data/config.js`                                                 |
+|         `LOG_PATH`          | Log storage path, default `./data/logs`                                                      |
+| `EXTENSION_GH_MIRROR_HOSTS` | Extension store GitHub mirror addresses, separate multiple with commas                       |
+|        `HTTP_PROXY`         | Proxy server, e.g. `127.0.0.1:2080`                                                          |
+
+## Build from source code
+
+```bash
+pnpm install
+pnpm run build:web
+cd build
+mkdir data
+# Create config file config.cjs
+node index.cjs
+```

--- a/docs/README_zh-tw.md
+++ b/docs/README_zh-tw.md
@@ -4,7 +4,7 @@
 
 <br />
 
-[English](../README.md) | [简体中文](README_zh.md) | 繁體中文
+[English](../README.md) | [简体中文](README_zh.md) | **繁體中文**
 
 專案仍在積極開發中，目前提供 **桌面版** 與 **網頁版服務**。
 
@@ -23,88 +23,7 @@
 
 ## 網頁版
 
-可以直接部署到伺服器，或使用 Docker 部署。
-
-### Docker 部署
-
-映像發佈地址：[https://hub.docker.com/r/lyswhut/any-listen-web-server](https://hub.docker.com/r/lyswhut/any-listen-web-server)
-
-### 直接部署
-
-> 要求：Node.js 20+
-
-下載最新版本並解壓到目標目錄：[https://github.com/any-listen/any-listen-web-server/releases](https://github.com/any-listen/any-listen-web-server/releases)
-
-參考 [https://github.com/lyswhut/lx-music-sync-server](https://github.com/lyswhut/lx-music-sync-server) 的部署方式，配置文件說明見下方。
-
-升級方式：
-
-1. 刪除舊版本專案目錄下的 `public` 與 `server` 資料夾
-2. 將新版本的 `public` 與 `server` 資料夾上傳到專案目錄
-3. 重新啟動服務
-
----
-
-**使用範例：**
-
-1. 建立配置文件 `data/config.cjs`
-
-    ```js
-    const config = {
-      // port: '9500', // 綁定埠口
-      // bindIp: '127.0.0.1', // 綁定 IP
-      // httpLog: true, // 是否啟用 HTTP 請求日誌
-      // 'cors.enabled': false, // 是否啟用跨域
-      // 'cors.whitelist': [ // 允許跨域的網域，空陣列表示允許所有網域
-      //   // 'www.xxx.com',
-      // ],
-      // 'upstreamProxy.enabled': false, // 是否使用代理轉發請求
-      // 'upstreamProxy.header': '', // 代理轉發請求標頭（如 `x-real-ip`）
-      // 'extension.ghMirrorHosts': [], // 擴展商店 Github 鏡像地址
-      // httpProxy: '', // 代理伺服器地址，例子 `127.0.0.1:2080`
-
-      // 允許訪問的本地目錄
-      // allowPublicDir: ['G:', 'E:\\music'], // Windows 範例
-      // allowPublicDir: ['/music'], // Linux 範例
-      password: '123456a', // 登入密碼
-    }
-
-    module.exports = config
-    ```
-
-2. 執行 Docker 容器
-
-    > 注意：以下命令僅為範例，請勿直接使用！
-
-    ```bash
-    docker run --volume=/home/music:/music --volume=/data:/server/data -p 8080:9500 -d test:latest
-    ```
-
-#### 環境變數
-
-|           變數名            | 描述                                                                                     |
-| :-------------------------: | ---------------------------------------------------------------------------------------- |
-|           `PORT`            | 綁定埠口，預設 `9500`                                                                    |
-|          `BIND_IP`          | 綁定 IP，預設 `127.0.0.1`，設為 `0.0.0.0` 接受所有 IPv4 請求，設為 `::` 接受所有 IP 請求 |
-|   `UPSTREAM_PROXY_HEADER`   | 代理轉發請求標頭（如 `x-real-ip`），設置後自動啟用代理                                   |
-|     `ALLOW_PUBLIC_DIR`      | 允許訪問的本地目錄，多個目錄用英文逗號分隔                                               |
-|         `DATA_PATH`         | 資料儲存路徑，預設 `./data`                                                              |
-|         `LOGIN_PWD`         | 登入密碼                                                                                 |
-|        `CONFIG_PATH`        | 配置文件路徑，預設 `./data/config.js`                                                    |
-|         `LOG_PATH`          | 日誌儲存路徑，預設 `./data/logs`                                                         |
-| `EXTENSION_GH_MIRROR_HOSTS` | 擴展商店 Github 鏡像地址，多個地址用英文逗號分隔                                         |
-|        `HTTP_PROXY`         | 代理伺服器，例如 `127.0.0.1:2080`                                                        |
-
-### 原始碼編譯
-
-```bash
-pnpm install
-pnpm run build:web
-cd build
-mkdir data
-# 建立配置文件 config.cjs
-node index.cjs
-```
+可以直接部署到伺服器，或使用 Docker 部署。部署流程、環境變數和原始碼編譯，詳見[部署指南](docker-server_zh-tw.md)。
 
 ## 貢獻
 

--- a/docs/README_zh.md
+++ b/docs/README_zh.md
@@ -4,7 +4,7 @@
 
 <br />
 
-[English](../README.md) | 简体中文 | [繁體中文](README_zh-tw.md)
+[English](../README.md) | **简体中文** | [繁體中文](README_zh-tw.md)
 
 项目仍在积极开发中，目前提供 **桌面版** 与 **网页版服务**。
 
@@ -23,88 +23,7 @@
 
 ## 网页版
 
-可以直接部署到服务器，或使用 Docker 部署。
-
-### Docker 部署
-
-镜像发布地址： [https://hub.docker.com/r/lyswhut/any-listen-web-server](https://hub.docker.com/r/lyswhut/any-listen-web-server)
-
-### 直接部署
-
-> 要求：Node.js 20+
-
-下载最新版本并解压到目标目录：[https://github.com/any-listen/any-listen-web-server/releases](https://github.com/any-listen/any-listen-web-server/releases)
-
-参考 [https://github.com/lyswhut/lx-music-sync-server](https://github.com/lyswhut/lx-music-sync-server) 的部署方式，配置文件说明见下方。
-
-升级方式：
-
-1. 删除旧版本项目目录下的 `public` 与 `server` 文件夹
-2. 将新版本的 `public` 与 `server` 文件夹上传到项目目录
-3. 重启服务
-
----
-
-**使用示例：**
-
-1. 创建配置文件 `data/config.cjs`
-
-    ```js
-    const config = {
-      // port: '9500', // 绑定端口
-      // bindIp: '127.0.0.1', // 绑定 IP
-      // httpLog: true, // 是否启用 HTTP 请求日志
-      // 'cors.enabled': false, // 是否启用跨域
-      // 'cors.whitelist': [ // 允许跨域的域名，空数组表示允许所有域名
-      //   // 'www.xxx.com',
-      // ],
-      // 'upstreamProxy.enabled': false, // 是否使用代理转发请求
-      // 'upstreamProxy.header': '', // 代理转发请求头（如 `x-real-ip`）
-      // 'extension.ghMirrorHosts': [], // 扩展商店 Github 镜像地址
-      // httpProxy: '', // 代理服务器地址，例子 `127.0.0.1:2080`
-
-      // 允许访问的本地目录
-      // allowPublicDir: ['G:', 'E:\\music'], // Windows 示例
-      // allowPublicDir: ['/music'], // Linux 示例
-      password: '123456a', // 登录密码
-    }
-
-    module.exports = config
-    ```
-
-2. 运行 Docker 容器
-
-    > 注意：以下命令仅为示例，不能直接使用！
-
-    ```bash
-    docker run --volume=/home/music:/music --volume=/data:/server/data -p 8080:9500 -d test:latest
-    ```
-
-#### 环境变量
-
-|           变量名            | 描述                                                                                     |
-| :-------------------------: | ---------------------------------------------------------------------------------------- |
-|           `PORT`            | 绑定端口，默认 `9500`                                                                    |
-|          `BIND_IP`          | 绑定 IP，默认 `127.0.0.1`，设为 `0.0.0.0` 接受所有 IPv4 请求，设为 `::` 接受所有 IP 请求 |
-|   `UPSTREAM_PROXY_HEADER`   | 代理转发请求头（如 `x-real-ip`），设置后自动启用代理                                     |
-|     `ALLOW_PUBLIC_DIR`      | 允许访问的本地目录，多个目录用英文逗号分隔                                               |
-|         `DATA_PATH`         | 数据存储路径，默认 `./data`                                                              |
-|         `LOGIN_PWD`         | 登录密码                                                                                 |
-|        `CONFIG_PATH`        | 配置文件路径，默认 `./data/config.js`                                                    |
-|         `LOG_PATH`          | 日志存储路径，默认 `./data/logs`                                                         |
-| `EXTENSION_GH_MIRROR_HOSTS` | 扩展商店 Github 镜像地址，多个地址用英文逗号分隔                                         |
-|        `HTTP_PROXY`         | 代理服务器，例子 `127.0.0.1:2080`                                                        |
-
-### 源码编译
-
-```bash
-pnpm install
-pnpm run build:web
-cd build
-mkdir data
-# 创建配置文件 config.cjs
-node index.cjs
-```
+可以直接部署到服务器，或使用 Docker 部署。部署流程、环境变量和源码编译，详见[部署指南](docker-server_zh.md)。
 
 ## 贡献代码
 

--- a/docs/docker-server_zh-tw.md
+++ b/docs/docker-server_zh-tw.md
@@ -1,0 +1,83 @@
+# Docker Server 部署指南
+
+## Docker 部署
+
+映像發佈地址：[https://hub.docker.com/r/lyswhut/any-listen-web-server](https://hub.docker.com/r/lyswhut/any-listen-web-server)
+
+## 直接部署
+
+> [!TIP]
+> 要求 Node.js 20+
+
+下載最新版本並解壓到目標目錄：[https://github.com/any-listen/any-listen-web-server/releases](https://github.com/any-listen/any-listen-web-server/releases)
+
+參考 [https://github.com/lyswhut/lx-music-sync-server](https://github.com/lyswhut/lx-music-sync-server) 的部署方式，配置文件說明見下方。
+
+升級方式：
+
+1. 刪除舊版本專案目錄下的 `public` 與 `server` 資料夾
+2. 將新版本的 `public` 與 `server` 資料夾上傳到專案目錄
+3. 重新啟動服務
+
+---
+
+**使用範例：**
+
+1. 建立配置文件 `data/config.cjs`
+
+    ```js
+    const config = {
+      // port: '9500', // 綁定埠口
+      // bindIp: '127.0.0.1', // 綁定 IP
+      // httpLog: true, // 是否啟用 HTTP 請求日誌
+      // 'cors.enabled': false, // 是否啟用跨域
+      // 'cors.whitelist': [ // 允許跨域的網域，空陣列表示允許所有網域
+      //   // 'www.xxx.com',
+      // ],
+      // 'upstreamProxy.enabled': false, // 是否使用代理轉發請求
+      // 'upstreamProxy.header': '', // 代理轉發請求標頭（如 `x-real-ip`）
+      // 'extension.ghMirrorHosts': [], // 擴充商店 GitHub 鏡像地址
+      // httpProxy: '', // 代理伺服器地址，例子 `127.0.0.1:2080`
+
+      // 允許訪問的本地目錄
+      // allowPublicDir: ['G:', 'E:\\music'], // Windows 範例
+      // allowPublicDir: ['/music'], // Linux 範例
+      password: '123456a', // 登入密碼
+    }
+
+    module.exports = config
+    ```
+
+2. 執行 Docker 容器
+
+    > 注意：以下指令僅為範例，請勿直接使用！
+
+    ```bash
+    docker run --volume=/home/music:/music --volume=/data:/server/data -p 8080:9500 -d test:latest
+    ```
+
+### 環境變數
+
+|           變數名            | 描述                                                                                     |
+| :-------------------------: | ---------------------------------------------------------------------------------------- |
+|           `PORT`            | 綁定埠口，預設 `9500`                                                                    |
+|          `BIND_IP`          | 綁定 IP，預設 `127.0.0.1`，設為 `0.0.0.0` 接受所有 IPv4 請求，設為 `::` 接受所有 IP 請求 |
+|   `UPSTREAM_PROXY_HEADER`   | 代理轉發請求標頭（如 `x-real-ip`），設置後自動啟用代理                                   |
+|     `ALLOW_PUBLIC_DIR`      | 允許訪問的本地目錄，多個目錄用英文逗號分隔                                               |
+|         `DATA_PATH`         | 資料儲存路徑，預設 `./data`                                                              |
+|         `LOGIN_PWD`         | 登入密碼                                                                                 |
+|        `CONFIG_PATH`        | 配置文件路徑，預設 `./data/config.js`                                                    |
+|         `LOG_PATH`          | 日誌儲存路徑，預設 `./data/logs`                                                         |
+| `EXTENSION_GH_MIRROR_HOSTS` | 擴充商店 GitHub 鏡像地址，多個地址用英文逗號分隔                                         |
+|        `HTTP_PROXY`         | 代理伺服器，例如 `127.0.0.1:2080`                                                        |
+
+## 原始碼編譯
+
+```bash
+pnpm install
+pnpm run build:web
+cd build
+mkdir data
+# 建立配置文件 config.cjs
+node index.cjs
+```

--- a/docs/docker-server_zh.md
+++ b/docs/docker-server_zh.md
@@ -1,0 +1,83 @@
+# Docker Server 部署指南
+
+## Docker 部署
+
+镜像发布地址： [https://hub.docker.com/r/lyswhut/any-listen-web-server](https://hub.docker.com/r/lyswhut/any-listen-web-server)
+
+## 直接部署
+
+> [!TIP]
+> 要求 Node.js 20+
+
+下载最新版本并解压到目标目录：[https://github.com/any-listen/any-listen-web-server/releases](https://github.com/any-listen/any-listen-web-server/releases)
+
+参考 [https://github.com/lyswhut/lx-music-sync-server](https://github.com/lyswhut/lx-music-sync-server) 的部署方式，配置文件说明见下方。
+
+升级方式：
+
+1. 删除旧版本项目目录下的 `public` 与 `server` 文件夹
+2. 将新版本的 `public` 与 `server` 文件夹上传到项目目录
+3. 重启服务
+
+---
+
+**使用示例：**
+
+1. 创建配置文件 `data/config.cjs`
+
+    ```js
+    const config = {
+      // port: '9500', // 绑定端口
+      // bindIp: '127.0.0.1', // 绑定 IP
+      // httpLog: true, // 是否启用 HTTP 请求日志
+      // 'cors.enabled': false, // 是否启用跨域
+      // 'cors.whitelist': [ // 允许跨域的域名，空数组表示允许所有域名
+      //   // 'www.xxx.com',
+      // ],
+      // 'upstreamProxy.enabled': false, // 是否使用代理转发请求
+      // 'upstreamProxy.header': '', // 代理转发请求头（如 `x-real-ip`）
+      // 'extension.ghMirrorHosts': [], // 扩展商店 GitHub 镜像地址
+      // httpProxy: '', // 代理服务器地址，例子 `127.0.0.1:2080`
+
+      // 允许访问的本地目录
+      // allowPublicDir: ['G:', 'E:\\music'], // Windows 示例
+      // allowPublicDir: ['/music'], // Linux 示例
+      password: '123456a', // 登录密码
+    }
+
+    module.exports = config
+    ```
+
+2. 运行 Docker 容器
+
+    > 注意：以下命令仅为示例，不能直接使用！
+
+    ```bash
+    docker run --volume=/home/music:/music --volume=/data:/server/data -p 8080:9500 -d test:latest
+    ```
+
+### 环境变量
+
+|           变量名            | 描述                                                                                     |
+| :-------------------------: | ---------------------------------------------------------------------------------------- |
+|           `PORT`            | 绑定端口，默认 `9500`                                                                    |
+|          `BIND_IP`          | 绑定 IP，默认 `127.0.0.1`，设为 `0.0.0.0` 接受所有 IPv4 请求，设为 `::` 接受所有 IP 请求 |
+|   `UPSTREAM_PROXY_HEADER`   | 代理转发请求头（如 `x-real-ip`），设置后自动启用代理                                     |
+|     `ALLOW_PUBLIC_DIR`      | 允许访问的本地目录，多个目录用英文逗号分隔                                               |
+|         `DATA_PATH`         | 数据存储路径，默认 `./data`                                                              |
+|         `LOGIN_PWD`         | 登录密码                                                                                 |
+|        `CONFIG_PATH`        | 配置文件路径，默认 `./data/config.js`                                                    |
+|         `LOG_PATH`          | 日志存储路径，默认 `./data/logs`                                                         |
+| `EXTENSION_GH_MIRROR_HOSTS` | 扩展商店 GitHub 镜像地址，多个地址用英文逗号分隔                                         |
+|        `HTTP_PROXY`         | 代理服务器，例子 `127.0.0.1:2080`                                                        |
+
+## 源码编译
+
+```bash
+pnpm install
+pnpm run build:web
+cd build
+mkdir data
+# 创建配置文件 config.cjs
+node index.cjs
+```


### PR DESCRIPTION
- Move Docker Server deployment instructions to a separate document
- Refine document formatting, phrasing, and word choice